### PR TITLE
Use TMotor_Antigravity_4004_300kv

### DIFF
--- a/user_j1.h
+++ b/user_j1.h
@@ -253,8 +253,8 @@ extern "C" {
 //#define USER_MOTOR Belt_Drive_Washer_IPM
 //#define USER_MOTOR Marathon_5K33GN2A
 //#define USER_MOTOR Anaheim_Salient
-//#define USER_MOTOR TMotor_Antigravity_4004_300kv
-#define USER_MOTOR TMotor_Antigravity_MN7005_115kv
+#define USER_MOTOR TMotor_Antigravity_4004_300kv
+//#define USER_MOTOR TMotor_Antigravity_MN7005_115kv
 
 
 

--- a/user_j5.h
+++ b/user_j5.h
@@ -250,8 +250,8 @@ extern "C" {
 //#define USER_MOTOR Belt_Drive_Washer_IPM
 //#define USER_MOTOR Marathon_5K33GN2A
 //#define USER_MOTOR Anaheim_Salient
-// #define USER_MOTOR TMotor_Antigravity_4004_300kv
-#define USER_MOTOR TMotor_Antigravity_MN7005_115kv
+#define USER_MOTOR TMotor_Antigravity_4004_300kv
+//#define USER_MOTOR TMotor_Antigravity_MN7005_115kv
 
 
 #if (USER_MOTOR == Estun_EMJ_04APB22)                  // Name must match the motor #define

--- a/user_mtr_on_j1.h
+++ b/user_mtr_on_j1.h
@@ -229,6 +229,7 @@ extern "C" {
 //! \brief Uncomment the motor which should be included at compile
 //! \brief These motor ID settings and motor parameters are then available to be used by the control system
 //! \brief Once your ideal settings and parameters are identified update the motor section here so it is available in the binary code
+// #define USER_MOTOR TMotor_Antigravity_MN7005_115kv
 #define USER_MOTOR TMotor_Antigravity_4004_300kv
 
 

--- a/user_mtr_on_j1.h
+++ b/user_mtr_on_j1.h
@@ -229,7 +229,7 @@ extern "C" {
 //! \brief Uncomment the motor which should be included at compile
 //! \brief These motor ID settings and motor parameters are then available to be used by the control system
 //! \brief Once your ideal settings and parameters are identified update the motor section here so it is available in the binary code
-#define USER_MOTOR TMotor_Antigravity_MN7005_115kv
+#define USER_MOTOR TMotor_Antigravity_4004_300kv
 
 
 

--- a/user_mtr_on_j5.h
+++ b/user_mtr_on_j5.h
@@ -229,6 +229,7 @@ extern "C" {
 //! \brief These motor ID settings and motor parameters are then available to be used by the control system
 //! \brief Once your ideal settings and parameters are identified update the motor section here so it is available in the binary code
 // #define USER_MOTOR_2 TMotor_Antigravity_4004_300kv_2
+// #define USER_MOTOR_2 TMotor_Antigravity_MN7005_115kv_2
 #define USER_MOTOR_2 TMotor_Antigravity_4004_300kv_2
 
 #if (USER_MOTOR_2 == Example_Motor_2)

--- a/user_mtr_on_j5.h
+++ b/user_mtr_on_j5.h
@@ -229,7 +229,7 @@ extern "C" {
 //! \brief These motor ID settings and motor parameters are then available to be used by the control system
 //! \brief Once your ideal settings and parameters are identified update the motor section here so it is available in the binary code
 // #define USER_MOTOR_2 TMotor_Antigravity_4004_300kv_2
-#define USER_MOTOR_2 TMotor_Antigravity_MN7005_115kv_2
+#define USER_MOTOR_2 TMotor_Antigravity_4004_300kv_2
 
 #if (USER_MOTOR_2 == Example_Motor_2)
 


### PR DESCRIPTION
## Description
Set the default configuration to TMotor_Antigravity_4004_300kv.

To my knowledge, this is the motor that is most widely used in the BLMC projects, so I think it makes sense to have this as default on the master.

In any case, there should be a specific branch for each motor configuration with a clear name.